### PR TITLE
Fix access widener declaration fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
 		"java": ">=17",
 		"fabric-api": "*"
 	},
-	"access_widener": "limlib.accesswidener",
+	"accessWidener": "limlib.accesswidener",
 	"custom": {
 		"modmenu": {
 			"badges": [


### PR DESCRIPTION
the access widener was declared as "access_widener", instead of "accessWidener", which was giving a warning in my log